### PR TITLE
Fix: React components could not load scss modules

### DIFF
--- a/src/declaration.d.ts
+++ b/src/declaration.d.ts
@@ -1,0 +1,1 @@
+declare module "*.module.scss";


### PR DESCRIPTION
Adding declaration to let the system know how to work with imports like `import styles from "Component.module.scss"`.